### PR TITLE
Fix: Display message when no shared users found (Closes #111)

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -457,6 +457,9 @@ def shared_with():
         user_ids.add(thread.sender_id if thread.sender_id != current_user.id else thread.recipient_id)
 
     users = User.query.filter(User.id.in_(user_ids)).all()
+    
+    has_shared_users = len(users) > 0
+    
     return render_template("shared_with.html", shared_users=users)
 
 @application.route('/search_users', methods=['GET'])

--- a/app/templates/shared_with.html
+++ b/app/templates/shared_with.html
@@ -7,14 +7,20 @@
   <div class="row justify-content-center">
     <div class="col-md-6 col-lg-5">
       <ul class="list-group">
-        {% for user in shared_users %}
-        <li class="list-group-item d-flex justify-content-between align-items-center">
-          {{ user.name }}
-          <a href="{{ url_for('view_shared_conversation', user_id=user.id) }}" class="btn btn-sm btn-outline-primary">
-            View Conversation
-          </a>
-        </li>
-        {% endfor %}
+        {% if has_shared_users %}
+          {% for user in shared_users %}
+          <li class="list-group-item d-flex justify-content-between align-items-center">
+            {{ user.name }}
+            <a href="{{ url_for('view_shared_conversation', user_id=user.id) }}" class="btn btn-sm btn-outline-primary">
+              View Conversation
+            </a>
+          </li>
+          {% endfor %}
+        {% else %}
+          <li class="list-group-item text-center">
+            You haven't shared anything with another user yet.
+          </li>
+        {% endif %}
       </ul>
     </div>
   </div>


### PR DESCRIPTION
It now shows a friendly message (You haven't shared anything yet.) if the current user has no shared review history with any user.
Previously, the page would appear empty without context which could confuse new users.